### PR TITLE
Fresh Dose of Nausea updates.

### DIFF
--- a/scripts/population/mvm_silentsky_rc4_int_fresh_dose_of_nausea.pop
+++ b/scripts/population/mvm_silentsky_rc4_int_fresh_dose_of_nausea.pop
@@ -867,7 +867,7 @@ WaveSchedule
 	Mission
 	{
 		Objective DestroySentries
-		Where spawnbot_mission_sentrybuster
+		Where spawnbot_alt
 
 		BeginAtWave 5
 		RunForThisManyWaves 1
@@ -2300,7 +2300,9 @@ WaveSchedule
         {
             Target wave_start_relay
             Action RunScriptCode
-            Param "PrecacheModel(`models/items/tf_gift.mdl`)"
+            Param "
+                PrecacheModel(`models/items/tf_gift.mdl`)
+                "
         }
 		DoneOutput
 		{
@@ -2570,7 +2572,7 @@ WaveSchedule
             MaxActive 3
             SpawnCount 1
 
-            Where spawnbot
+            Where spawnbot_alt
 
             WaitForAllSpawned "wave01"
             WaitBeforeStarting 6


### PR DESCRIPTION
Implements certain changes to make the mission more functional, as some bots used to get stuck in spawn on occasion extending the wave time greatly.