### PR TITLE
Fix mvm_rottenburg_int_german_gears.pop

### DIFF
--- a/scripts/population/mvm_rottenburg_int_german_gears.pop
+++ b/scripts/population/mvm_rottenburg_int_german_gears.pop
@@ -1521,7 +1521,8 @@ WaveSchedule
 				TFBot
 				{
 					Template T_TFBot_Giant_Soldier_RapidFire
-					ClassIcon soldier_Spammer
+					//ClassIcon soldier_Spammer //Don't you love it when conventional "don't use cases to separate icons because it doesn't work on Linux" is ignored? :D
+					ClassIcon soldier_spammer_giant
 				}
 				TFBot
 				{


### PR DESCRIPTION
Fixed w6 rapid gsolly icon stacking with permission from the mission maker. Very salty comment.