### PR TITLE
Update mvm_dockyard_rc7_adv_cargo_carnage.pop

### DIFF
--- a/scripts/population/mvm_dockyard_rc7_adv_cargo_carnage.pop
+++ b/scripts/population/mvm_dockyard_rc7_adv_cargo_carnage.pop
@@ -939,6 +939,7 @@ WaveSchedule
 			TFBot
 			{
 				Template T_TFBot_Heavyweapons_Fist
+				Tag bot_giant
 			}	
 		}
 		


### PR DESCRIPTION
yknow i remember back in bb1 when like 5 different giants missing bot_giant were found. guess this one slipped through cause its a minigiant.